### PR TITLE
meson: Build fixes

### DIFF
--- a/hawck-ui/meson.build
+++ b/hawck-ui/meson.build
@@ -15,4 +15,6 @@ run_target('hawck-ui',
   command : [python3.find_python(), 'setup.py', 'build'],
 )
 
-meson.add_install_script('install-hawck-ui.sh')
+if get_option('use_meson_install')
+  meson.add_install_script('install-hawck-ui.sh')
+endif

--- a/hawck-ui/setup.py
+++ b/hawck-ui/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python3
 
-import setuptools, json
+import os, setuptools, json
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open("../build/hawck-ui/setup_config.json") as rf:
+MESON_BUILD_ROOT = os.environ.get('MESON_BUILD_ROOT') or '../build'
+
+with open(os.path.join(MESON_BUILD_ROOT, "hawck-ui/setup_config.json")) as rf:
     config = json.load(rf)
 
 setuptools.setup(


### PR DESCRIPTION
Some more meson build fixes which should aid packaging.

This solves some issues I encountered when writing a Gentoo ebuild for Hawck. The install-hawck-ui.sh was failing in their sandbox (distros will call setup.py manually anyway) so I added a check for the `use_meson_install` option you added in a310172dd44dcb106c5cb331d480f178df36e41f.

The setup.py was failing because by default Gentoo builds meson projects out-of-tree so instead of there being a ./build directory there's one outside of the source-tree named ../hawck-build so I added a check for the `$MESON_BUILD_ROOT` variable and use this if it's set (only falling back to `../build` if this variable isn't set for some reason). I'm not a meson expert so I'm not sure if this is the correct variable to use but it works for me at least.