### PR TITLE
fix build with meson 0.54.x and project version

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -31,10 +31,10 @@ configure_file(
   configuration: conf
 )
 
-hawck_install_configured = configure_file(
+configure_file(
   input: 'hawck-install.sh.in',
   output: 'hawck-install.sh',
   configuration: conf
 )
 
-hawck_install_script = find_program(hawck_install_configured)
+hawck_install_script = join_paths(meson.current_build_dir(), 'hawck-install.sh')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('Hawck', 'c', 'cpp',
-        version : '0.7',
+        version : '0.7.1',
         license : 'BSD-2',
         meson_version : '>=0.49.0',
         default_options : ['c_std=c18',


### PR DESCRIPTION
By the way, is meson 0.49.0 a hard requirement? Seems to me that everything with such a version won't have gcc10, but I haven't researched it much. 0.53.0 would solve a small problem elsewhere.