### PR TITLE
Add logs and fix missing keymaps and keys

### DIFF
--- a/src/Lua/Keymap.lua
+++ b/src/Lua/Keymap.lua
@@ -264,7 +264,7 @@ function kbmap.getall()
   end
 
   local p = io.popen(("find %s -name '*map.gz'"):format(u.shescape(kbmap_path)))
-  local keymap_rx = ".*/([a-z0-9]+)/([a-z0-9]+)/([a-z0-9-]+)%.k?map%.gz"
+  local keymap_rx = ".*/([a-z0-9]+)/([a-z0-9]+)/([a-z0-9-.]+)%.k?map%.gz"
   local keymaps = {}
   for line in p:lines() do
     local machine, layout, lang = line:match(keymap_rx)

--- a/src/Lua/Keymap.lua
+++ b/src/Lua/Keymap.lua
@@ -282,7 +282,7 @@ function kbmap.new(lang)
   assert(lang)
   local maps = kbmap.getall()
   if not maps[lang] then
-    error("No such keymap: " .. lang)
+    error("No such keymap: " .. lang .. ". Available: " .. table.concatkeys(maps, " "))
   end
   local keymap, combo_map, mod_codes = readLinuxKBMap(maps[lang])
   local map = {
@@ -309,7 +309,7 @@ function kbmap:getKeysym(key)
   if ALIASES and ALIASES[key] then
     key = ALIASES[key]
   end
-  return self.keymap[key] or error(("No such key: %s"):format(key))
+  return self.keymap[key] or error(("No such key: %s. Available keys: %s"):format(key, table.concatkeys(self.keymap, " ")))
 end
 
 --- Check if a key is a modifier, i.e one of Control/Control_R/Shift/Shift_R/Alt/AltGr

--- a/src/Lua/Keymap.lua
+++ b/src/Lua/Keymap.lua
@@ -102,7 +102,7 @@ end
 --             /usr/share/kbd/keymaps/i386/qwerty/no-latin1.map.gz
 function readLinuxKBMap(path)
   local include_line_rx = "^[\t ]*include \"(.*)\""
-  local keymap_line_rx =  "^[\t ]*keycode *([0-9]+) *= *([0-9a-zA-Z+]+) *(.*)$"
+  local keymap_line_rx =  "^[\t ]*keycode *([0-9]+) *= *([0-9a-zA-Z+_]+) *(.*)$"
 
   local orig_path = path
   local has_gz = path:endswith(".gz")
@@ -148,7 +148,7 @@ function readLinuxKBMap(path)
         end
         table.insert(modifiers, key)
       end
-      local alt_code, alt_name = line:match(".*keycode *([0-9]+) *= *([a-zA-Z0-9+]+)")
+      local alt_code, alt_name = line:match(".*keycode *([0-9]+) *= *([a-zA-Z0-9+_]+)")
       -- We only care about the plain ones for now.
       if modifiers[1] == "plain" then
         code, name, rest = alt_code, alt_name, ""

--- a/src/Lua/utils.lua
+++ b/src/Lua/utils.lua
@@ -1,18 +1,18 @@
 --[====================================================================================[
    Various utility functions for Lua
-   
+
    Copyright (C) 2018 Jonas Møller (no) <jonasmo441@gmail.com>
    All rights reserved.
-   
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are met:
-   
+
    1. Redistributions of source code must retain the above copyright notice, this
       list of conditions and the following disclaimer.
    2. Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-   
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -55,7 +55,7 @@ function u.join(...)
 end
 
 --- Curry a function.
--- 
+--
 -- Example:
 --   curry((function (a, b) return a + b end), 2) ->
 --     function (b) return 2 + b end -- (Essentially)
@@ -402,7 +402,7 @@ function u.expect(typen, var)
 end
 
 --- Expand environment variables in the given string.
--- 
+--
 -- Environment variables should appear in the form: $variable
 --
 -- @tparam string path
@@ -470,6 +470,21 @@ function table.update(dst, src)
     dst[k] = v
   end
   return dst
+end
+
+---
+--
+-- Like table.concat, but for keys of associative string->x arrays.
+--
+-- @param t Source Table
+-- @param sep Separator to use eg " "
+-- @return dst
+function table.concatkeys(t, sep)
+  local ret = ""
+  for k,v in pairs(t) do
+    ret = ret .." " .. k
+  end
+  return ret
 end
 
 --- Get directory name of path

--- a/src/Lua/utils.lua
+++ b/src/Lua/utils.lua
@@ -479,12 +479,13 @@ end
 -- @param t Source Table
 -- @param sep Separator to use eg " "
 -- @return dst
-function table.concatkeys(t, sep)
-  local ret = ""
-  for k,v in pairs(t) do
-    ret = ret .." " .. k
+function table.concatkeys(tab, sep)
+  local ctab, n = {}, 1
+  for k, _ in pairs(tab) do
+      ctab[n] = k
+      n = n + 1
   end
-  return ret
+  return table.concat(ctab, sep)
 end
 
 --- Get directory name of path


### PR DESCRIPTION
## 1. Add useful logs to 'No such key' and 'No such keymap' errors

This gives the following on my Ubuntu 22.04

Related: #75

Keymap.lua:289: Available keymaps: pt-latin1 fr-x11 no-standard ua-utf-ws cf us cz-lat2 sunt5-trqalt se-fi-ir209 sunt5-no is-latin1-us sunt4-no-latin1 mac-es mac-dvorak amiga-se no-latin1 dk amiga-it atari-se atari-uk kk slovene mac-pt-latin1 mac-fi-latin1 sg-latin1 mac-usb-pt-latin1 ru-ms pl-qwertz es ro-academic dvorak-l mac-usb-fr bg-cp1251 lisp-us dvorak ua-utf fr-latin1 dvorak-lisp lk201-us br-latin1 emacs mac-macbook-de mac-usb-dvorak gr-pc fr-pc dvorak-r mac-de2-ext wangbe br-abnt2 be-latin1 sunt5-fr-latin1 de-latin1 emacs2 it-ibm amiga-de atari-us-deadkeys amiga-us mac-usb-us de gr-utf8 ru se-latin1 mac-us-ext sunt5-uk dvorak-uk mac-usb-euro trqu hu sk-prog-qwerty mac-us-std se-lat6 mac-us-dvorak by amiga-es mac-de-latin1 mac-us be2-latin1 hu101 atari-se-deadkeys sk-qwertz ru-yawerty sunt5-cz-us ar fr gr atari-de-deadkeys se-ir209 trq pc-dvorak-latin1 mac-se mac-fr2-ext atari-us mac-ibook-de mac-ibook-de-deadkeys atari-de dvorak-de sr sunt5-fi-latin1 sk-prog mac-usb-uk ua-ws ibook2-uk hebrew kg mac-it sunt4-fi-latin1 sunt5-ru mac-fr-ext se-fi-lat6 sunt4-es is-latin1 dvorak-fr-bepo bg dk-latin1 sunt5-es croat sg-latin1-lk450 dvorak-fr-bepo-utf8 ibook-it sunt5-ja sunkeymap sun-pl sunt5-de-latin1 il-heb sunt6-uk ru4 no sunt5-us-cz pc110 ro-comma sk-prog-qwertz fr-latin9 mac-uk wo atari-de-emacs sk-qwerty atari-uk-deadkeys lv-latin4 mac-usb-be uaw mac-macbook-fr atari-fr mac-usb-se ru-cp1251 sr-cy mac-usb-es azerty pl jp106 pt-old ru3 cz-us-qwerty fi dvorak-classic nl tralt ca-multi il mac-usb-dk-latin1 it mac-fr3 cz-us-qwertz lt et mac-usb-de-latin1 defkeymap cz-lat2-prog sundvorak mac-usb-de-latin1-nodeadkeys es-cp850 lv-latin7 ro ru2 sun-pl-altgraph amiga-sg sg et-nodeadkeys fa us-latin1 dvorak-fr sunt4-ja mac-usb-it fi-latin1 mac-usb-fi-latin1 la-latin1 mk il-phonetic amiga-fr th-tis mac-fr mac-de-latin1-nodeadkeys pl1 de-latin1-nodeadkeys uk ua ru1 it2 fr-latin0 dvorak-ru 


And with `keymap = "defkeymap"`:

Keymap.lua:313: No such key: KP_9. Available keys:  1 2 3 4 5 6 7 8 9
10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 55 56 57 58 59 60 61 62 63 64 g f e d k j i h o n m l s 
r q p Prior KP_R minus Last Pause 119 F17 F5 c b a F2 117 Caps Do 3 Help 115 Left space Scroll 114 F13 113 105 Escape 112 100 7 6 5 4 Down Return 9 8 F6 Delete Insert Control backslash grav
e 66 Next F8 65 Alt 67 68 69 Num F9 Select bracketright F10 Right apostrophe 2 1 0 70 semicolon Macro 104 84 comma 86 87 88 F7 bracketleft F12 Find 102 Break period Control_R less KP Remove
F11 101 Shift_R 103 AltGr equal 106 107 108 109 110 111 w v u t 116 z y x F1 F14 F4 Tab Up Shift F3 slash


that's where I get the inspiration for the rest, eg having only "KP" seems suspicious (see #72 / #10)

## 2. '.' can be part of keymaps

eg on Ubuntu 22.04 the following exist:
lt.l4 us-intl.iso01 us-intl.iso15"

## 3. Fix parsing of key names containing '_' like KP_Enter etc. Fixes #10, #72

Before the change: "No such key: KP_9"
After: no error the csv contains the proper code:
```
> cat /var/lib/hawck-input/keys/example.csv
key_name,key_code
"KP_9",73
```