### PR TITLE
[proposal] let 'replace' remap keys even with modifers

### DIFF
--- a/changelogs/changelog_0.8.0.md
+++ b/changelogs/changelog_0.8.0.md
@@ -1,0 +1,15 @@
+# Changelog for 0.8.0
+
+- Breaking changes
+  - `replace` and `sub` now work with modifiers instead of actively silencing them
+
+- Features:
+  - Now finds keymaps with '.' in their names
+
+- Misc. changes
+  - only use NOTIFY_URGENCY_CRITICAL notifs when adequate
+  - Added useful logs to 'No such key' and 'No such keymap' errors
+  - Added feedback in case included keymaps fail to parse
+
+- Bugfixes:
+  - Fix parsing of key names containing '\_' like KP_Enter etc. Fixes #10, #72

--- a/src/Lua/Hawck.lua
+++ b/src/Lua/Hawck.lua
@@ -1,18 +1,18 @@
 --[====================================================================================[
    Hawck main library.
-   
+
    Copyright (C) 2018 Jonas Møller (no) <jonasmo441@gmail.com>
    All rights reserved.
-   
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are met:
-   
+
    1. Redistributions of source code must retain the above copyright notice, this
       list of conditions and the following disclaimer.
    2. Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-   
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -115,13 +115,11 @@ insert = LazyF.new(function (str)
 end)
 
 replace = LazyF.new(function (key)
-    kbd:withCleanMods(function ()
         if kbd:hadKeyDown() then
           kbd:down(key)
         elseif kbd:hadKeyUp() then
           kbd:up(key)
         end
-    end)
 end)
 sub = replace
 


### PR DESCRIPTION
in my opinion if I write
`key "b" => replace "a"`
then I expect pressing `Shift+b` to write symbol `A` ; Currently it writes `a`
and I expect `Control+b` to send `Control-a` (typically select-all shortcut) ; Currently it writes `a`

of course If I really want exact text then I can still do `key "b" => insert "a"` 

I really don't see many uses for the current behavior, but I understand it may be better to instead add new method perhaps named `remap`, so as to not break existing code *(also since `sub` and `replace` are aliases one of them could be kept as-is?)*
